### PR TITLE
fixed typo in fixtures preventing them from being executed

### DIFF
--- a/emailvalidator/fixtures/emailvalidator-any.json
+++ b/emailvalidator/fixtures/emailvalidator-any.json
@@ -11,7 +11,7 @@
         "pk": 5,
         "fields": {
             "regex": ".*",
-            "EmailDomainGroup": 3
+            "group_id": 3
         }
     }
 ]

--- a/emailvalidator/fixtures/emailvalidator-goc.json
+++ b/emailvalidator/fixtures/emailvalidator-goc.json
@@ -11,7 +11,7 @@
         "pk": 5,
         "fields": {
             "regex": "^.*@.*\\.gc\\.ca$",
-            "EmailDomainGroup": 3
+            "group_id": 3
         }
     },
     {
@@ -19,7 +19,7 @@
         "pk": 6,
         "fields": {
             "regex": "^.*@canada.ca$",
-            "EmailDomainGroup": 3
+            "group_id": 3
         }
     }
 ]


### PR DESCRIPTION
Typo if fixtures prevented them loading, to test

    python manage.py loaddata emailvalidator-goc

Should create a group for GoC with 2 predefined regex patterns
